### PR TITLE
Fix begin_regular_gameplay called in first move of elynia

### DIFF
--- a/episode2/scenarios/01_By_the_Moonlight.cfg
+++ b/episode2/scenarios/01_By_the_Moonlight.cfg
@@ -54,7 +54,7 @@
     [side]
         side=2
         controller=null
-        team_name=good
+        team_name=neutral
         user_team_name= _ "team_name^Humans"
 
         hidden=yes
@@ -240,6 +240,7 @@
         [modify_side]
             side=2
             controller=ai
+            team_name=good
             hidden=no
             {DEFAULT_ECONOMY}
             {GOLD 70 60 50}


### PR DESCRIPTION
@shikadiqueen Now what allied side visible in shroud, doing of side 2 an ennemy before the regular gameplay is an idea for reolve the problem https://github.com/project-ethea/After_the_Storm/issues/40