### PR TITLE
E2S1 set fire_event=no in [kill] for avoid call of two last breath events when Daent killed by Elynia

### DIFF
--- a/episode2/scenarios/01_By_the_Moonlight.cfg
+++ b/episode2/scenarios/01_By_the_Moonlight.cfg
@@ -630,7 +630,7 @@
         {THUNDER (
             [kill]
                 id=Daent
-                fire_event=yes
+                fire_event=no
                 animate=yes
             [/kill]
         )}
@@ -658,7 +658,7 @@
 
         [kill]
             id=Daent
-            fire_event=yes
+            fire_event=no
             animate=no
         [/kill]
 


### PR DESCRIPTION
@shikadiqueen fire_event in die of Daent is no use and when he is killed by Elynia, kill function call the other if fire_event=yes. It must set fire_event=no for avois this.