### PR TITLE
fix aspect_of_darkness_obscures in neutral TOD

### DIFF
--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -83,7 +83,7 @@ As such, it has access to the following abilities:
     [illuminates]
         id=aspect_of_darkness_obscures
         value=-25
-        max_value=-25
+        min_value=-25
         cumulative=no
         affect_self=yes
     [/illuminates]


### PR DESCRIPTION
@shikadiqueen i know, in ats when aspect_of_darkness_obscures is used, tod is ever chaotic but is for the readers of wml code